### PR TITLE
1872-10-24

### DIFF
--- a/1872 Test Criteria.md
+++ b/1872 Test Criteria.md
@@ -40,13 +40,13 @@ Also such other tests by firing and exposure as the Board my desire to apply.
 * No person will be admitted to the firing ground but the agents or exhibitors of the gun immediately under trial, and such other persons as may be specifically invited by the Board.
 
 ## Tests
-1. *Rapidity with aim* - The number of shots which, fired in one minute, strike a target 6 feet by 2 feet at a distance of 100 feet. Any cartridges missing fire [misfires] in this or other tests to be tried with a prick-punch, or opened to ascertain the cause of failure. The test to be begun with an empty chamber or magazine, the cartridges to be disposed at will on a table.
-2. *Rapidity at will* - The number of shots that can be fired in one minute, irrespective of aim.
-3. *Endurance* - Each gun to be fired 500 continuous rounds, without cleaning. The state of the breech-mechanism to be examined at the end of every 50-rounds.
-4. *Defective cartridges* - Each gun to be fired once with each of the following defective cartridges:
+1. *Defective cartridges* - Each gun to be fired once with each of the following defective cartridges:
    1. Cross-filed on head to nearly the thickness of the metal.
    2. Cut at intervals around the rim.
    3. With a longitudinal cut the whole length of the cartridge from the rim up. A fresh piece of white paper marked with the number of the gun being laid over the breech to observe the escape of gas, if any occurs.
-5. *Dust* - The piece to be exposed in a box prepared for that purpose to blast of find sand-dust for __ minutes; to be removed, fired 50 rounds, replaced for 5 minutes, removed and fired 50 rounds more.
-6. *Rust* - The breech mechanism and receiver to be cleansed of grease and the chamber of the barrel greased and plugged, the butt of the gun to be inserted into the height of the chamber in a solution of sal-ammoniac for 10 minutes, exposed for two days to the open air standing in a rack, and then fired 50 rounds.
+2. *Rapidity with aim* - The number of shots which, fired in one minute, strike a target 6 feet by 2 feet at a distance of 100 feet. Any cartridges missing fire [misfires] in this or other tests to be tried with a prick-punch, or opened to ascertain the cause of failure. The test to be begun with an empty chamber or magazine, the cartridges to be disposed at will on a table.
+3. *Rapidity at will* - The number of shots that can be fired in one minute, irrespective of aim.
+4. *Endurance* - Each gun to be fired 500 continuous rounds, without cleaning. The state of the breech-mechanism to be examined at the end of every 50-rounds.
+5. *Dust* - The piece to be exposed in a box prepared for that purpose to blast of find sand-dust for __ minutes; to be removed, fired 20 rounds, replaced for 5 minutes, removed and fired 20 rounds more.
+6. *Rust* - The breech mechanism and receiver to be cleansed of grease and the chamber of the barrel greased and plugged, the butt of the gun to be inserted into the height of the chamber in a solution of sal-ammoniac for 10 minutes, exposed for two days to the open air standing in a rack, and then fired 20 rounds.
 7. *Excessive charges* - To be fired once with 85 grains of powder and one ball of 450 grains of lead; once with 90 grains and one ball; and once with 90 grains and two balls. The piece to be closely examined after each discharge.


### PR DESCRIPTION
The Board met on October 24th, 1872.
Present: Colonels Hagner and Clitz, Major Reno, Captain Livingston, and the recorder. Absent: General Terry.

Order of rules changed to first test defective cartridges; number of test shots reduced from 50 to 20 for Rust and Dust tests.