### PR TITLE
1873-04-10

### DIFF
--- a/1872 Test Criteria.md
+++ b/1872 Test Criteria.md
@@ -39,6 +39,7 @@ Also such other tests by firing and exposure as the Board my desire to apply.
 * The service-cartridge to be used in all cases where the gun is chambered for it, except in the special trials made by exhibiors.
 * No person will be admitted to the firing ground but the agents or exhibitors of the gun immediately under trial, and such other persons as may be specifically invited by the Board.
 * After the rusting test the guns may be cleaned in the shop; prior to that no one should clean them but the employee. The only cleaning requisite during the experiments, and prior to rusting, is to oil and wipe the breech-mechanism, and wipe out the barrel. No cleaning or wiping should be done during the experiments, unless in the presence of the Board, or by special direction.
+* Supplemental severe tests may not be conducted on a gun which had not endured the preliminary trials.
 
 ## Tests
 1. *Defective cartridges* - Each gun to be fired once with each of the following defective cartridges:


### PR DESCRIPTION
The Board met on April 10th, 1873.
Present: All the members and the recorder.

Rule adopted to clarify that participation in the initial trials would be a prerequisite for conducting the tests of increased severity.